### PR TITLE
Add no-failure shell script for Google Cloud Build (#75)

### DIFF
--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -7,4 +7,5 @@ licenses(["notice"])  # Apache 2.0
 exports_files([
     "LICENSE",
     "conftest.sh",
+    "conftest-nofail.sh",
 ])

--- a/tests/conftest-nofail.sh
+++ b/tests/conftest-nofail.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Variant of conftest.sh to always succeed, but still report errors in test output.
+# Necessary to work around a limitation in GCB for the conformance test dashboard
+# (could change when GCB feature to allow passing builds when steps fail is released).
+
+(exec "$@")
+exit 0


### PR DESCRIPTION
Necessary to work around GCB limitation for conformance test dashboard.